### PR TITLE
Remove naive middleware check for a griddler path

### DIFF
--- a/griddler-ses.gemspec
+++ b/griddler-ses.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "sinatra", "~> 1.4"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/griddler/ses/adapter.rb
+++ b/lib/griddler/ses/adapter.rb
@@ -19,7 +19,7 @@ module Griddler
       def normalize_params
         # use sns_endpoint to parse and validate the sns message
         sns_msg = SnsEndpoint::AWS::SNS::Message.new sns_json
-        raise "Invalid SNS message" unless sns_msg.authentic? && sns_msg.topic_arn.end_with?('griddler')
+        raise "Invalid SNS message" unless sns_msg.authentic?
 
         case sns_msg.type
         when :SubscriptionConfirmation

--- a/lib/griddler/ses/middleware.rb
+++ b/lib/griddler/ses/middleware.rb
@@ -9,7 +9,7 @@ module Griddler
         # a bug on the AWS side doesn't set the content type to application/json type properly,
         # so we have to intercept and do this in order for Griddler's controller to correctly
         # parse the parameters (see https://forums.aws.amazon.com/thread.jspa?messageID=418160)
-        if is_griddler_request?(env) && is_aws_sns_request?(env)
+        if is_aws_sns_request?(env)
           env['CONTENT_TYPE'] = 'application/json; charset=UTF-8'
         end
 
@@ -17,14 +17,6 @@ module Griddler
       end
 
       private
-      def griddler_path
-        @griddler_path ||= Rails.application.routes.url_helpers.url_for(controller: 'griddler/emails', action: 'create', only_path: true)
-      end
-
-      def is_griddler_request?(request)
-        request['REQUEST_PATH'] == griddler_path
-      end
-
       def is_aws_sns_request?(request)
         request['HTTP_X_AMZ_SNS_MESSAGE_TYPE'].present?
       end

--- a/lib/griddler/ses/railtie.rb
+++ b/lib/griddler/ses/railtie.rb
@@ -2,7 +2,14 @@ module Griddler
   module Ses
     class Railtie < Rails::Railtie
       initializer "griddler_ses.configure_rails_initialization" do |app|
-        Rails.application.middleware.insert_before ActionDispatch::ParamsParser, Griddler::Ses::Middleware
+        if ::Rails::VERSION::MAJOR >= 5
+          # Rails 5 no longer instantiates ActionDispatch::ParamsParser
+          # https://github.com/rails/rails/commit/a1ced8b52ce60d0634e65aa36cb89f015f9f543d
+          Rails.application.middleware.use Middleware
+          Rails.application.middleware.use Griddler::Ses::Middleware
+        else
+          Rails.application.middleware.insert_before ActionDispatch::ParamsParser, Griddler::Ses::Middleware
+        end
       end
     end
   end


### PR DESCRIPTION
1. Mounting Griddler is not a requirement: https://github.com/thoughtbot/griddler#installation
2. The check didn't take domains/subdomains into account
3. Checking for the HTTP_X_AMZ_SNS_MESSAGE_TYPE header is sufficient
4. **This actually breaks if Griddler is not mounted**
